### PR TITLE
Allow configuration of a separate dial timeout

### DIFF
--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -129,7 +129,7 @@ func NewFromSelector(ss ServerSelector) *Client {
 // Client is a memcache client.
 // It is safe for unlocked use by multiple concurrent goroutines.
 type Client struct {
-	// DialTimeout specified the timeout when dialling a new connection to Memcached.
+	// DialTimeout specifies the timeout when dialling a new connection to Memcached.
 	// If zero, DefaultTimeout is used.
 	DialTimeout time.Duration
 


### PR DESCRIPTION
This allows a more aggressive timeout for dial than we would use for normal operations (on an already-open socket).
